### PR TITLE
Rename `ignition_ros2_control` to `ign_ros2_control`

### DIFF
--- a/panda_description/launch/view.launch.py
+++ b/panda_description/launch/view.launch.py
@@ -206,8 +206,8 @@ def generate_declared_arguments() -> List[DeclareLaunchArgument]:
         ),
         DeclareLaunchArgument(
             "ros2_control_plugin",
-            default_value="ignition",
-            description="The ros2_control plugin that should be loaded for the manipulator ('fake', 'ignition', 'real' or custom).",
+            default_value="ign",
+            description="The ros2_control plugin that should be loaded for the manipulator ('fake', 'ign', 'real' or custom).",
         ),
         DeclareLaunchArgument(
             "ros2_control_command_interface",

--- a/panda_description/panda/model.sdf
+++ b/panda_description/panda/model.sdf
@@ -727,7 +727,7 @@
       </visual>
     </link>
     <static>false</static>
-    <plugin name='ignition_ros2_control::IgnitionROS2ControlPlugin' filename='ignition_ros2_control-system'>
+    <plugin name='ign_ros2_control::IgnitionROS2ControlPlugin' filename='ign_ros2_control-system'>
       <parameters>/home/andrej/ws/code/repos/panda_ign_moveit2/install/share/panda_moveit_config/config/controllers_effort.yaml</parameters>
     </plugin>
   </model>

--- a/panda_description/scripts/xacro2sdf.bash
+++ b/panda_description/scripts/xacro2sdf.bash
@@ -13,7 +13,7 @@ XACRO_ARGS=(
     collision_arm:=true
     collision_gripper:=true
     ros2_control:=true
-    ros2_control_plugin:=ignition
+    ros2_control_plugin:=ign
     ros2_control_command_interface:=effort
     gazebo_preserve_fixed_joint:=false
 )

--- a/panda_description/scripts/xacro2urdf.bash
+++ b/panda_description/scripts/xacro2urdf.bash
@@ -12,7 +12,7 @@ XACRO_ARGS=(
     collision_arm:=true
     collision_gripper:=true
     ros2_control:=true
-    ros2_control_plugin:=ignition
+    ros2_control_plugin:=ign
     ros2_control_command_interface:=effort
     gazebo_preserve_fixed_joint:=false
 )

--- a/panda_description/urdf/panda.gazebo
+++ b/panda_description/urdf/panda.gazebo
@@ -5,11 +5,11 @@
   <!--       -->
   <!-- Macro -->
   <!--       -->
-  <xacro:macro name="ignition_ros2_control" params="
+  <xacro:macro name="ign_ros2_control" params="
    controller_parameters
   ">
     <gazebo>
-      <plugin filename="ignition_ros2_control-system" name="ignition_ros2_control::IgnitionROS2ControlPlugin">
+      <plugin filename="ign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin">
         <parameters>${controller_parameters}</parameters>
       </plugin>
     </gazebo>

--- a/panda_description/urdf/panda.ros2_control
+++ b/panda_description/urdf/panda.ros2_control
@@ -25,13 +25,13 @@
         <xacro:if value="${plugin == 'fake'}">
           <plugin>fake_components/GenericSystem</plugin>
         </xacro:if>
-        <xacro:if value="${plugin == 'ignition'}">
-          <plugin>ignition_ros2_control/IgnitionSystem</plugin>
+        <xacro:if value="${plugin == 'ign'}">
+          <plugin>ign_ros2_control/IgnitionSystem</plugin>
         </xacro:if>
         <xacro:if value="${plugin == 'real'}">
           <xacro:ERROR_ros2_control_for_real_robot_unimplemented/>
         </xacro:if>
-        <xacro:unless value="${plugin == 'fake' or plugin == 'ignition' or plugin == 'real'}">
+        <xacro:unless value="${plugin == 'fake' or plugin == 'ign' or plugin == 'real'}">
           <plugin>${plugin}</plugin>
         </xacro:unless>
       </hardware>
@@ -162,13 +162,13 @@
         <xacro:if value="${plugin == 'fake'}">
           <plugin>fake_components/GenericSystem</plugin>
         </xacro:if>
-        <xacro:if value="${plugin == 'ignition'}">
-          <plugin>ignition_ros2_control/IgnitionSystem</plugin>
+        <xacro:if value="${plugin == 'ign'}">
+          <plugin>ign_ros2_control/IgnitionSystem</plugin>
         </xacro:if>
         <xacro:if value="${plugin == 'real'}">
           <xacro:ERROR_ros2_control_for_real_robot_unimplemented/>
         </xacro:if>
-        <xacro:unless value="${plugin == 'fake' or plugin == 'ignition' or plugin == 'real'}">
+        <xacro:unless value="${plugin == 'fake' or plugin == 'ign' or plugin == 'real'}">
           <plugin>${plugin}</plugin>
         </xacro:unless>
       </hardware>

--- a/panda_description/urdf/panda.urdf
+++ b/panda_description/urdf/panda.urdf
@@ -352,7 +352,7 @@
   </joint>
   <ros2_control name="panda_arm_system" type="system">
     <hardware>
-      <plugin>ignition_ros2_control/IgnitionSystem</plugin>
+      <plugin>ign_ros2_control/IgnitionSystem</plugin>
     </hardware>
     <joint name="panda_joint1">
       <param name="initial_position">0.0</param>
@@ -529,7 +529,7 @@
   </joint>
   <ros2_control name="panda_gripper_system" type="system">
     <hardware>
-      <plugin>ignition_ros2_control/IgnitionSystem</plugin>
+      <plugin>ign_ros2_control/IgnitionSystem</plugin>
     </hardware>
     <joint name="panda_finger_joint1">
       <param name="initial_position">0.0</param>
@@ -547,7 +547,7 @@
     </joint>
   </ros2_control>
   <gazebo>
-    <plugin filename="ignition_ros2_control-system" name="ignition_ros2_control::IgnitionROS2ControlPlugin">
+    <plugin filename="ign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin">
       <parameters>/home/andrej/ws/code/repos/panda_ign_moveit2/install/share/panda_moveit_config/config/controllers_effort.yaml</parameters>
     </plugin>
   </gazebo>

--- a/panda_description/urdf/panda.urdf.xacro
+++ b/panda_description/urdf/panda.urdf.xacro
@@ -38,8 +38,8 @@
 
   <!-- Flag to enable ros2 controllers for manipulator -->
   <xacro:arg name="ros2_control" default="true"/>
-  <!-- The ros2_control plugin that should be loaded for the manipulator ('fake', 'ignition', 'real' or custom) -->
-  <xacro:arg name="ros2_control_plugin" default="ignition"/>
+  <!-- The ros2_control plugin that should be loaded for the manipulator ('fake', 'ign', 'real' or custom) -->
+  <xacro:arg name="ros2_control_plugin" default="ign"/>
   <!-- The output control command interface provided by ros2_control ('position', 'velocity', 'effort' or certain combinations 'position,velocity') -->
   <xacro:arg name="ros2_control_command_interface" default="effort"/>
   <!-- The filepath to parameters of ROS 2 controllers -->
@@ -109,8 +109,8 @@
 
   <!-- Gazebo - ROS 2 control (Ignition) -->
   <xacro:if value="$(arg ros2_control)">
-    <xacro:if value="${'ignition' in '$(arg ros2_control_plugin)'}">
-      <xacro:ignition_ros2_control controller_parameters="$(arg ros2_controller_parameters)"/>
+    <xacro:if value="${'ign' in '$(arg ros2_control_plugin)'}">
+      <xacro:ign_ros2_control controller_parameters="$(arg ros2_controller_parameters)"/>
     </xacro:if>
   </xacro:if>
 

--- a/panda_moveit_config/launch/ex_ign_control.launch.py
+++ b/panda_moveit_config/launch/ex_ign_control.launch.py
@@ -53,7 +53,7 @@ def generate_launch_description() -> LaunchDescription:
                 )
             ),
             launch_arguments=[
-                ("ros2_control_plugin", "ignition"),
+                ("ros2_control_plugin", "ign"),
                 ("ros2_control_command_interface", "effort"),
                 # TODO: Re-enable colligion geometry for manipulator arm once spawning with specific joint configuration is enabled
                 ("collision_arm", "false"),

--- a/panda_moveit_config/launch/move_group.launch.py
+++ b/panda_moveit_config/launch/move_group.launch.py
@@ -420,8 +420,8 @@ def generate_declared_arguments() -> List[DeclareLaunchArgument]:
         ),
         DeclareLaunchArgument(
             "ros2_control_plugin",
-            default_value="ignition",
-            description="The ros2_control plugin that should be loaded for the manipulator ('fake', 'ignition', 'real' or custom).",
+            default_value="ign",
+            description="The ros2_control plugin that should be loaded for the manipulator ('fake', 'ign', 'real' or custom).",
         ),
         DeclareLaunchArgument(
             "ros2_control_command_interface",

--- a/panda_moveit_config/package.xml
+++ b/panda_moveit_config/package.xml
@@ -14,7 +14,7 @@
   <exec_depend>control_msgs</exec_depend>
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>hardware_interface</exec_depend>
-  <exec_depend>ignition_ros2_control</exec_depend>
+  <exec_depend>ign_ros2_control</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>moveit_ros_move_group</exec_depend>


### PR DESCRIPTION
Change applied according to [ignitionrobotics/ign_ros2_control#19](https://github.com/ignitionrobotics/ign_ros2_control/pull/19).