### PR TITLE
Replace load_yaml with xacro.load_yaml

### DIFF
--- a/panda_description/urdf/panda.ros2_control
+++ b/panda_description/urdf/panda.ros2_control
@@ -18,7 +18,7 @@
    command_interface:=effort
    initial_positions_file:=${default_initial_positions_file}
   ">
-    <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_joint_positions']['panda_arm']}"/>
+    <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_joint_positions']['panda_arm']}"/>
 
     <ros2_control name="${name}" type="system">
       <hardware>
@@ -155,7 +155,7 @@
    initial_positions_file:=${default_initial_positions_file}
    mimic_joints:=false
   ">
-    <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_joint_positions']['panda_gripper']}"/>
+    <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_joint_positions']['panda_gripper']}"/>
 
     <ros2_control name="${name}" type="system">
       <hardware>


### PR DESCRIPTION
`load_yaml` is deprecated, and this PR replaces it with `xacro.load_yaml`.

# Testing

In ROS2 Humble (Ubuntu 22.04), without this change I ran `ros2 launch panda_moveit_config ex_fake_control.launch.py` and got the following exception:

```
$ ros2 launch panda_moveit_config ex_fake_control.launch.py
[INFO] [launch]: All log files can be found below ~/.ros/log/2023-12-20-14-11-06-705317-ubuntuvm-128001
[INFO] [launch]: Default logging verbosity is set to INFO
[ERROR] [launch]: Caught exception in launch (see debug for traceback): executed command showed stderr output. Command: /opt/ros/humble/bin/xacro ~/Workspaces/ada_ws/install/panda_description/share/panda_description/urdf/panda.urdf.xacro name:=panda prefix:=panda_ gripper:=true collision_arm:=true collision_gripper:=true safety_limits:=true safety_position_margin:=0.15 safety_k_position:=100.0 safety_k_velocity:=40.0 ros2_control:=true ros2_control_plugin:=fake ros2_control_command_interface:=position gazebo_preserve_fixed_joint:=false
Captured stderr output:
warning: Using load_yaml() directly is deprecated. Use xacro.load_yaml() instead.
warning: Using load_yaml() directly is deprecated. Use xacro.load_yaml() instead.

$
```
After this change, I rebuilt and re-ran the command, and it launched without exception.