### PR TITLE
Enable OMPL Constrained Planning

### DIFF
--- a/panda_moveit_config/config/ompl_planning.yaml
+++ b/panda_moveit_config/config/ompl_planning.yaml
@@ -124,6 +124,8 @@ planner_configs:
     type: geometric::TrajOpt
 
 arm:
+  enforce_constrained_state_space: true
+  projection_evaluator: joints(panda_joint1,panda_joint2)
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault


### PR DESCRIPTION
This PR was motivated by [`pymoveit2`#48](https://github.com/AndrejOrsula/pymoveit2/pull/42) and enables [OMPL Constrained Planning](https://moveit.picknik.ai/main/doc/how_to_guides/using_ompl_constrained_planning/ompl_constrained_planning.html), to make planning with an orientation path constraint more efficient